### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "install": "^0.12.2",
     "node-libs-browser": "^1.0.0",
     "node-sass": "^4.12.0",
-    "npm": "^6.9.0",
     "react": "^16.8.6",
     "react-addons-test-utils": "^15.1.0",
     "react-bootstrap": "^1.0.0-beta.8",


### PR DESCRIPTION

Hello yairv13!

It seems like you have npm as one of your (dev-) dependency in class_plus_client.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
